### PR TITLE
Multiple webinar table & click to populate webinar key bug fixes

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -9,7 +9,7 @@
     <email>support@vedaconsulting.co.uk</email>
   </maintainer>
   <releaseDate>2015-11-17</releaseDate>
-  <version>1.5.1</version>
+  <version>1.6</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>

--- a/info.xml
+++ b/info.xml
@@ -8,11 +8,11 @@
     <author>Veda Consulting</author>
     <email>support@vedaconsulting.co.uk</email>
   </maintainer>
-  <releaseDate>2015-05-07</releaseDate>
-  <version>1.5</version>
+  <releaseDate>2015-11-17</releaseDate>
+  <version>1.5.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.5</ver>
+    <ver>4.6</ver>
   </compatibility>
   <comments></comments>
   <civix>

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
@@ -33,7 +33,9 @@
 <script> 
 cj(document).ready(function() {
   var webinar_settings = cj('#webinarTableWarpper').html();
-  cj("input[data-crm-custom='Webinar_Event:Webinar_id']").parent().parent().parent().parent().after(webinar_settings);
+  if (cj('#webinarTableWarpper').length == 0) {
+    cj("input[data-crm-custom='Webinar_Event:Webinar_id']").parent().parent().parent().parent().after(webinar_settings);
+  };
 		  
   cj(document).tooltip();
      
@@ -48,15 +50,15 @@ cj(document).ready(function() {
   });
   
   cj('#webinar_settings tbody').on('click', 'tr', function (){            
-    var fieldname ='#custom_'+window.custid+'_-1';    
+    var fieldname ='#custom_'+window.custid+'_1';    
     var name = cj('td', this).eq(2).text();
     cj(fieldname).val(name);
   });
   
   cj('#webinar_settings').dataTable(); 
-  if(cj(window.ids).length==0){
-    cj('#webinarTableWarpper').hide(); 
-  }
+  // if(cj(window.ids).length==0){
+  //   cj('#webinarTableWarpper').hide(); 
+  // }
 });		    
 </script>
 {/literal}


### PR DESCRIPTION
*On newer versions Civi creates forms for custom fields. So, we check for any webinar table created before we create one.
*wrong id format on Click to populate webinar key function fixed 
