### PR TITLE
BASW-640: Fix HTML for gotoWebinar settings page

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.extra.tpl
@@ -2,35 +2,42 @@
   {$error_message.message}
 {/if}
 {if $upcomingWebinars}
-  <div id="webinarTableWarpper">
-    <h2>Click any row below to populate Webinar Key.</h2><br />
-
-    <table id="webinar_settings" cellspacing="0" width="100%" >
-
-      <thead>
-        <tr>
-          <th>Description</th>
-          <th>Subject</th>
-          <th>Webinar Key</th>
-          <th>Start Time</th>
-          <th>End Time</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        {foreach from=$upcomingWebinars item=webinar}
-        {assign var=times value=$webinar.times}
-          <tr>
-            <td style="cursor: pointer; sortable="true">{$webinar.description}</td>
-            <td style="cursor: pointer; class='subject' sortable="true">{$webinar.subject}</td>
-            <td class='webminarKey' sortable="true" style="cursor: pointer;" title="Click the key to populate Webinar Key.">{$webinar.webinarKey}</td>
-            <td style="cursor: pointer; sortable="true">{$times[0].startTime|crmDate}</td>
-            <td style="cursor: pointer; sortable="true">{$times[0].endTime|crmDate}</td>
-          </tr>
-        {/foreach}
-      </tbody>
-    </table>
+<div class="crm-accordion-wrapper crm-accordion-open">
+  <div class="crm-accordion-header">
+      {ts}Webinar Key Settings{/ts}
   </div>
+  <div class="crm-accordion-body">
+    <div id="webinarTableWarpper">
+      <h4><strong>Click any row below to populate Webinar Key.</strong></h4>
+
+      <table id="webinar_settings" cellspacing="0" width="100%" >
+
+        <thead>
+          <tr>
+            <th>Description</th>
+            <th>Subject</th>
+            <th>Webinar Key</th>
+            <th>Start Time</th>
+            <th>End Time</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {foreach from=$upcomingWebinars item=webinar}
+          {assign var=times value=$webinar.times}
+            <tr>
+              <td style="cursor: pointer; sortable="true">{$webinar.description}</td>
+              <td style="cursor: pointer; class='subject' sortable="true">{$webinar.subject}</td>
+              <td class='webminarKey' sortable="true" style="cursor: pointer;" title="Click the key to populate Webinar Key.">{$webinar.webinarKey}</td>
+              <td style="cursor: pointer; sortable="true">{$times[0].startTime|crmDate}</td>
+              <td style="cursor: pointer; sortable="true">{$times[0].endTime|crmDate}</td>
+            </tr>
+          {/foreach}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
 
 {literal}
 <script>

--- a/templates/CRM/Gotowebinar/Form/Setting.tpl
+++ b/templates/CRM/Gotowebinar/Form/Setting.tpl
@@ -6,8 +6,29 @@
       {ts}Client Secret Setting{/ts}
     </div><!-- /.crm-accordion-header -->
     <div class="crm-accordion-body">
+      {if !$initial}
+       <div>
+        <div>
+          <label>{ts}Participant Status To Be Considered {/ts}</label>
+        </div>
+        <div class="listing-box" style="height: 120px">
+            {foreach from=$form.participant_status_id item="participant_status_val"}
+                <div class="{cycle values="odd-row,even-row"}">
+                    {$participant_status_val.html}
+                </div>
+            {/foreach}
+        </div>
+      </div>
+      <br/>
+      <br/>
+      {/if}
 
-      <table class="form-layout-compressed">
+      {if $responseKey}
+        <div class="crm-webinar-information-api-key-block alert alert-info">
+            <strong>Info:</strong> Your account is connected.&nbsp;Here are your Upcoming Webinars
+        </div>
+      {/if}
+      <table class="dataTable">
       {if $initial}
         <tr class="crm-webinar-setting-api-key-block">
           <td class="label">{$form.api_key.label}</td>
@@ -37,55 +58,41 @@
             </span>
           </td>
         </tr>
-        {else}
-         <tr>
-            <td ><label>{ts}Participant Status To Be Considered {/ts}</label>
-                <br />
-                <div class="listing-box" style="height: 120px">
-                    {foreach from=$form.participant_status_id item="participant_status_val"}
-                        <div class="{cycle values="odd-row,even-row"}">
-                            {$participant_status_val.html}
-                        </div>
-                    {/foreach}
-                </div>
-            </td>
-        </tr>
         {/if}
         {if $responseKey}
-            <tr class="crm-webinar-information-api-key-block">
-                <td class="label" style="color:green"><b>{ts} Info:{/ts}</td>
-                <td class="label" style="color:green"><b>{ts}Your account is connected.&nbsp;Here are your Upcoming Webinars {/ts}</td>
-            </tr>
-            <tr style="background-color: #CDE8FE;">
-                      <td><b>{ts}Description{/ts}</td>
-                      <td><b>{ts}Subject{/ts}</td>
-                      <td><b>{ts}Webinar Key{/ts}</td>
-                      <td><b>{ts}Start Time{/ts}</td>
-                      <td><b>{ts}End Time{/ts}</td>
+          <thead >
+            <tr>
+              <th>{ts}Description{/ts}</th>
+              <th>{ts}Subject{/ts}</th>
+              <th>{ts}Webinar Key{/ts}</th>
+              <th>{ts}Start Time{/ts}</th>
+              <th>{ts}End Time{/ts}</th>
            </tr>
-            {foreach from=$upcomingWebinars item=webinar}
+           <tbody>
+              {foreach from=$upcomingWebinars item=webinar}
                 <tr>
-                <td>{$webinar.description}</td>
-                <td>
-                  {$webinar.subject}
-                  <p style="color: red;">{$webinar.warning}</p>
-                </td>
-                <td>{$webinar.webinarKey}</td>
-                {assign var=times value=$webinar.times}
-                <td>{$times[0].startTime|crmDate}</td>
-                <td>{$times[0].endTime|crmDate}</td>
+                  <td>{$webinar.description}</td>
+                  <td>
+                    {$webinar.subject}
+                    <p style="color: red;">{$webinar.warning}</p>
+                  </td>
+                  <td>{$webinar.webinarKey}</td>
+                  {assign var=times value=$webinar.times}
+                  <td>{$times[0].startTime|crmDate}</td>
+                  <td>{$times[0].endTime|crmDate}</td>
                 </tr>
-            {/foreach}
+              {/foreach}
+            </tbody>
         {/if}
         {if $clienterror}
             <tr class="crm-webinar-information-erro-api-key-block">
-            <td class="label" style="color:red"><b>{ts} Info:{/ts}</td>
+            <td class="label" style="color:red">{ts} Info:{/ts}</td>
             <td class="label" style="color:red">{ts}{$clienterror.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$clienterror.msg}{/ts}</td>
             </tr>
         {/if}
         {if $error}
             <tr class="crm-webinar-information-erro-api-key-block">
-            <td class="label" style="color:red"><b>{ts} Info:{/ts}</td>
+            <td class="label" style="color:red">{ts} Info:{/ts}</td>
             <td class="label" style="color:red">{ts}{$error.int_err_code}{/ts}&nbsp;&nbsp;&nbsp;&nbsp;{ts}{$error.msg}{/ts}</td>
             </tr>
         {/if}
@@ -96,4 +103,3 @@
     </div>
   </div>
 </div>
-


### PR DESCRIPTION
## Overview
This PR fixes HTML of
 * Webinar settings page
 * Webinar key form on events page

### Webinar settings - core civi styles
#### Before
<img width="1671" alt="Screenshot 2020-05-26 at 10 53 03 PM" src="https://user-images.githubusercontent.com/3340537/82983310-7c616c80-a00d-11ea-86c1-48dbda457606.png">

#### After
<img width="1675" alt="Screenshot 2020-05-26 at 10 49 57 PM" src="https://user-images.githubusercontent.com/3340537/82983322-81beb700-a00d-11ea-9695-1b69db4d7f9b.png">

### Webinar settings - with shoreditch theme
#### Before
<img width="1678" alt="Screenshot 2020-05-26 at 9 44 22 PM" src="https://user-images.githubusercontent.com/3340537/82983355-8f743c80-a00d-11ea-8a94-a10e7f1c80a9.png">

#### After
<img width="1658" alt="Screenshot 2020-05-26 at 10 44 34 PM" src="https://user-images.githubusercontent.com/3340537/82983408-a74bc080-a00d-11ea-80c1-0b4b26667031.png">


### Webinar form on events - core civi styles
#### Before
<img width="1667" alt="Screenshot 2020-05-27 at 3 54 55 PM" src="https://user-images.githubusercontent.com/3340537/83012233-c3188c00-a038-11ea-8612-87cd9789193e.png">

#### After
<img width="1658" alt="Screenshot 2020-05-27 at 4 36 27 PM" src="https://user-images.githubusercontent.com/3340537/83012259-c875d680-a038-11ea-99ad-63a3b1fee855.png">


### Webinar form on events -  with shoreditch theme
#### Before
<img width="1672" alt="Screenshot 2020-05-27 at 3 44 04 PM" src="https://user-images.githubusercontent.com/3340537/83012319-d9bee300-a038-11ea-8dac-60135d306315.png">


#### After
<img width="1667" alt="Screenshot 2020-05-27 at 4 41 23 PM" src="https://user-images.githubusercontent.com/3340537/83012392-f4915780-a038-11ea-9b4c-754d7c8792ac.png">



## Technical Details
### Webinar settings page
`Form/Setting.tpl ` is updated to move the listbox and the info text out of table and apply core civicrm classes and shoreditch classes to make it consistent.
Also, added `dataTable` class to the table tag and provided correct html tags to the table headers.

### Webinar form on events 
For this section HTML for `templates/CRM/Gotowebinar/Form/Setting.tpl` is updated and the form is rendered as a civicrm accordion, so that things look consistent with the remaining form.
